### PR TITLE
Add ability to configure syslog plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ auditd_default_arch: b64
 # You can opt to start the auditd service or not.
 # Mostly useful in CI, to avoid starting the service.
 auditd_start_service: true
+
+# This section includes configuration for the syslog plugin
+# The role will loop through the dict and for each item it
+# will create\update a property of the same name in the
+# plugins.d/syslog.conf file
+auditd_plugin_syslog:
+  active: "yes"
+  direction: out
+  path: /sbin/audisp-syslog
+  type: always
+
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,3 +48,13 @@ auditd_default_arch: b64
 # You can opt to start the auditd service or not.
 # Mostly useful in CI, to avoid starting the service.
 auditd_start_service: true
+
+# See below an example of the configuration of the syslog plugin
+# No other plugins are supported currently
+# auditd_plugin_syslog:
+#   active: "yes"
+#   direction: out
+#   path: /sbin/audisp-syslog
+#   type: always
+#   args: LOG_LOCAL0
+#   format: string

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,16 @@
   when:
     - auditd_manage_rules
 
+- name: Configure syslog plugin for auditd
+  community.general.ini_file:
+    path: "{{ auditd_config_directory }}/plugins.d/syslog.conf"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    mode: '0640'
+    state: present
+  loop: "{{ auditd_plugin_syslog | dict2items }}"
+  when: auditd_plugin_syslog is defined
+
 - name: Start and enable auditd
   ansible.builtin.service:
     name: "{{ auditd_service }}"


### PR DESCRIPTION
This change adds the ability to specify syslog plugin configuration. Configuration is passed as a dict named auditd_plugin_syslog which contains items in key: value format. The ini_file module is used to loop through all items in the dict and update them one by one.

This avoids either replacing the whole file with a template or resorting to lineinfile which has unpredictable results.

Was tested using using a vars file containing the new dict with a number of properties against a machine with a pre-existing syslog.conf file.