### PR TITLE
Add option to create a new log namespace for auditd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ auditd_tcp_client_max_idle: 0
 auditd_enable_krb5: "no"
 auditd_krb5_principal: auditd
 auditd_distribute_network: "no"
+auditd_journal_context: false
 
 # You can opt to manage the rules with this role or not.
 # Setting auditd_manage_rules to false will not manage the rules.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -22,3 +22,15 @@
     use: service  # systemctl can't restart auditd, service can: https://access.redhat.com/solutions/2664811
   when:
     - auditd_start_service
+
+- name: Restart systemd-journald
+  ansible.builtin.systemd_service:
+    name: systemd-journald
+    state: restarted
+    daemon_reload: true
+
+- name: Restart systemd-journald@audit
+  ansible.builtin.systemd_service:
+    name: systemd-journald@audit
+    state: restarted
+    daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,54 @@
   loop: "{{ auditd_plugin_syslog | dict2items }}"
   when: auditd_plugin_syslog is defined
 
+- name: Create a Seperate Journald Context for auditd
+  when: auditd_journal_context is true
+  block:
+    - name: Create journald drop-in directory
+      ansible.builtin.file:
+        name: /etc/systemd/journald.conf.d/
+        state: directory
+        mode: "0755"
+
+    - name: Create auditd Journal Context
+      ansible.builtin.template:
+        src: journald@audit.conf.j2
+        dest: /etc/systemd/journald.conf.d/journald@audit.conf
+        mode: "0644"
+      notify: 
+        - Restart systemd-journald
+        - Restart systemd-journald@audit
+
+    - name: Restart Journald to Activate the New Context
+      ansible.builtin.meta: flush_handlers
+
+- name: Configure auditd to use this new context
+  when: auditd_journal_context is true
+  block:
+    - name: Check whether override file exists
+      ansible.builtin.stat:
+        path: /etc/systemd/system/auditd.service
+      register: auditd_service_override
+
+    - name: Prepare the override file
+      ansible.builtin.command:
+        cmd: systemctl cat auditd.service > /etc/systemd/system/auditd.service
+      when: auditd_service_override.stat is not defined
+
+    - name: Configure the Logging Context
+      community.general.ini_file:
+        path: /etc/systemd/system/auditd.service
+        section: Service
+        option: LogNamespace
+        value: audit
+        mode: "0644"
+      notify:
+        - Restart auditd
+        - Restart systemd-journald
+
+    - name: Restart Auditd to Activate the New Context
+      ansible.builtin.meta: flush_handlers
+
 - name: Start and enable auditd
   ansible.builtin.service:
     name: "{{ auditd_service }}"

--- a/templates/journald@audit.conf.j2
+++ b/templates/journald@audit.conf.j2
@@ -1,0 +1,7 @@
+[Journal]
+# These Settings keep auditd from spilling overflow messages into the console. The default
+# values can be foudn in /etc/systemd/journald.conf
+Storage=volatile
+RuntimeMaxUse=100M
+ForwardToSyslog=no
+ForwardToWall=no


### PR DESCRIPTION
---
name: AuditD Log Namespace

---
**Description**
The code within this PR was written to address a single problem we are having with auditd - that logs keep polluting our journal. Unfortunately there is no great way to do a negative match filter on the journals within journalctl so the solution that was designed was to separate all auditd logs into a seperate journald log namespace. For anyone who uses the journal extensively for troubleshooting, the value of separating the auditd logs off should be self-evident.

**Testing**
Special care was taken to make sure we don't break any current functionality. The feature is off by default and if you opt in there shouldn't be anything that conflicts with the role's current capabilities.

I have tested it extensively against hosts that have been provisioned with the current role and with which we seek to migrate to being provisioned with this new version of the role.