### PR TITLE
Feat/add journald logging context

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@
 extends: default
 
 rules:
+  command-instead-of-module: false
   braces:
     max-spaces-inside: 1
     level: error

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,7 +19,6 @@
   ansible.builtin.service:
     name: "{{ auditd_service }}"
     state: restarted
-    use: service  # systemctl can't restart auditd, service can: https://access.redhat.com/solutions/2664811
   when:
     - auditd_start_service
 
@@ -29,8 +28,14 @@
     state: restarted
     daemon_reload: true
 
-- name: Restart systemd-journald@audit
+- name: Restart systemd-journald@audit.service
   ansible.builtin.systemd_service:
-    name: systemd-journald@audit
+    name: systemd-journald@audit.service
+    state: restarted
+    daemon_reload: true
+
+- name: Restart systemd-journald-audit.socket
+  ansible.builtin.systemd_service:
+    name: systemd-journald-audit.socket
     state: restarted
     daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,7 @@
         src: journald@audit.conf.j2
         dest: /etc/systemd/journald.conf.d/journald@audit.conf
         mode: "0644"
-      notify: 
+      notify:
         - Restart systemd-journald
         - Restart systemd-journald@audit
 
@@ -82,8 +82,15 @@
 
     - name: Prepare the override file
       ansible.builtin.command:
-        cmd: systemctl cat auditd.service > /etc/systemd/system/auditd.service
+        cmd: systemctl cat auditd.service
       when: auditd_service_override.stat.exists is false
+      register: cat_auditd_service
+
+    - name: Copy using inline content
+      ansible.builtin.copy:
+        content: "{{ cat_auditd_service.stdout }}"
+        dest: /etc/systemd/system/auditd.service
+      when: cat_auditd_service
 
     - name: Configure the Logging Context
       community.general.ini_file:
@@ -106,3 +113,12 @@
     enabled: true
   when:
     - auditd_start_service
+
+- name: Start and enable systemd-journald@audit
+  ansible.builtin.service:
+    name: "systemd-journald@audit"
+    state: started
+    enabled: true
+  when:
+    - auditd_start_service
+    - auditd_journal_context is true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,65 +54,103 @@
 - name: Create a Seperate Journald Context for auditd
   when: auditd_journal_context is true
   block:
-    - name: Create journald drop-in directory
-      ansible.builtin.file:
-        name: /etc/systemd/journald.conf.d/
-        state: directory
-        mode: "0755"
-
     - name: Create auditd Journal Context
       ansible.builtin.template:
         src: journald@audit.conf.j2
-        dest: /etc/systemd/journald.conf.d/journald@audit.conf
+        dest: /etc/systemd/journald@audit.conf
         mode: "0644"
       notify:
         - Restart systemd-journald
-        - Restart systemd-journald@audit
 
     - name: Restart Journald to Activate the New Context
       ansible.builtin.meta: flush_handlers
 
-- name: Configure auditd to use this new context
+- name: Configure systemd overrides
   when: auditd_journal_context is true
-  block:
-    - name: Check whether override file exists
-      ansible.builtin.stat:
-        path: /etc/systemd/system/auditd.service
-      register: auditd_service_override
+  ansible.builtin.include_tasks:
+    file: systemd_overrides.yml
+  loop:
+    - auditd.service
+    - systemd-journald-audit.socket
+    - systemd-journald@audit.service
+    - systemd-journald.service
 
-    - name: Prepare the override file
-      ansible.builtin.command:
-        cmd: systemctl cat auditd.service
-      when: auditd_service_override.stat.exists is false
-      register: cat_auditd_service
+- name: Remove the systemd-journald-auditd.socket from systemd-journald.service
+  community.general.ini_file:
+    path: /etc/systemd/system/systemd-journald.service
+    section: Service
+    option: Sockets
+    value: "journald.socket systemd-journald-dev-log.socket"
+    mode: "0644"
+    exclusive: true
+    state: present
+    no_extra_spaces: true
+  notify:
+    - Restart systemd-journald
 
-    - name: Copy using inline content
-      ansible.builtin.copy:
-        content: "{{ cat_auditd_service.stdout }}"
-        dest: /etc/systemd/system/auditd.service
-      when: cat_auditd_service
+- name: Add systemd-journald@audit.service to systemd-journald-audit.socket
+  community.general.ini_file:
+    path: /etc/systemd/system/systemd-journald-audit.socket
+    section: Socket
+    option: Service
+    value: systemd-journald@audit.service
+    mode: "0644"
+    exclusive: true
+    state: present
+    no_extra_spaces: true
+  notify:
+    - Restart systemd-journald-audit.socket
+    - Restart systemd-journald@audit.service
 
-    - name: Configure the Logging Context
-      community.general.ini_file:
-        path: /etc/systemd/system/auditd.service
-        section: Service
-        option: LogNamespace
-        value: audit
-        mode: "0644"
-      notify:
-        - Restart auditd
-        - Restart systemd-journald
+- name: Add systemd-journald-audit.socket to systemd-journald@audit.service
+  community.general.ini_file:
+    path: /etc/systemd/system/systemd-journald@audit.service
+    section: Service
+    option: Sockets
+    value: "systemd-journald@%i.socket systemd-journald-audit.socket"
+    mode: "0644"
+    exclusive: true
+    no_extra_spaces: true
+  notify:
+    - Restart systemd-journald@audit.service
 
-    - name: Restart Auditd to Activate the New Context
-      ansible.builtin.meta: flush_handlers
+- name: Add systemd-journald-audit.socket to systemd-journald@audit.service Requires
+  community.general.ini_file:
+    path: /etc/systemd/system/systemd-journald@audit.service
+    section: Unit
+    option: Requires
+    value: "systemd-journald@%i.socket systemd-journald-varlink@%i.socket systemd-journald-audit.socket"
+    mode: "0644"
+    exclusive: true
+    no_extra_spaces: true
+  notify:
+    - Restart systemd-journald@audit.service
 
-- name: Start and enable auditd
-  ansible.builtin.service:
-    name: "{{ auditd_service }}"
-    state: started
-    enabled: true
-  when:
-    - auditd_start_service
+- name: Add systemd-journald-audit.socket to systemd-journald@audit.service After
+  community.general.ini_file:
+    path: /etc/systemd/system/systemd-journald@audit.service
+    section: Unit
+    option: After
+    value: "systemd-journald@%i.socket systemd-journald-varlink@%i.socket systemd-journald-audit.socket"
+    mode: "0644"
+    exclusive: true
+    no_extra_spaces: true
+  notify:
+    - Restart systemd-journald@audit.service
+
+- name: Configure the Logging Context
+  community.general.ini_file:
+    path: /etc/systemd/system/auditd.service
+    section: Service
+    option: LogNamespace
+    value: audit
+    mode: "0644"
+    no_extra_spaces: true
+  notify:
+    - Restart auditd
+
+- name: Restart any services that were notified
+  ansible.builtin.meta: flush_handlers
 
 - name: Start and enable systemd-journald@audit
   ansible.builtin.service:
@@ -122,3 +160,11 @@
   when:
     - auditd_start_service
     - auditd_journal_context is true
+
+- name: Start and enable auditd
+  ansible.builtin.service:
+    name: "{{ auditd_service }}"
+    state: started
+    enabled: true
+  when:
+    - auditd_start_service

--- a/tasks/systemd_overrides.yml
+++ b/tasks/systemd_overrides.yml
@@ -1,0 +1,19 @@
+---
+- name: systemd_overrides | Check whether override file exists
+  ansible.builtin.stat:
+    path: "/etc/systemd/system/{{ item }}"
+  register: service_override
+
+- name: systemd_overrides | Prepare the override file
+  ansible.builtin.command:
+    cmd: "systemctl cat {{ item }}"
+    creates: "/etc/systemd/system/{{ item }}"
+  when: service_override.stat.exists is false
+  register: cat_service
+
+- name: systemd_overrides | Copy using inline content
+  ansible.builtin.copy:
+    content: "{{ cat_service.stdout }}"
+    mode: "0644"
+    dest: "/etc/systemd/system/{{ item }}"
+  when: service_override.stat.exists is false


### PR DESCRIPTION
---
name: Rework Journald Namespace Configuration
---

After an unsuccessful attempt at fixing the previous error I discovered many more issues with the final configuration of the services where they would succeed for a short while and then eventually fail.

Unfortunately I wasn't exactly clear on how journald recieves and records audit events so this took quite a bit of trial and error to get just right.

I now create override files by using systemd to reliable produce them as would be the case by using systemctl edit --full <name>.<unit type> which was important to me for the purposes of not carrying over an old template that I would have to maintain forever.

I loop through the needed services with a task list (instead of messy blocks everywhere) and then apply my changes on the generated override.
The override is only generated if there is no file already. If someone makes a change to the override we don´t override the whole file we only make sure that the parameter we need is not changed. Meaning users can still make changes that won't break our configuration should they want to.
